### PR TITLE
DOCACCORDI-9: marker from a list is not displayed in main document

### DIFF
--- a/src/main/resources/docaccordion.css
+++ b/src/main/resources/docaccordion.css
@@ -4,3 +4,8 @@
   font-style: italic;   
   padding-top: 5px;
 }
+/* The only element affected by the "panel" class is "ul" and we need to reset the style applied and keep the included
+   content as it is. */
+.xwiki-accordion-content ul {
+  all: revert;
+}


### PR DESCRIPTION
* Revert the style inherited from the ".panel ul" using CSS "all" property with "revert" value.
* Revert is supported by Mozilla Firefox and Safari, but there are open issues to be supported soon on Microsoft Edge and Google Chrome.
* On the browsers that do not support it, nothing is breaking.